### PR TITLE
Fix: Handle 409 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v24.44.0
+
+- Add retry logic for 409 errors when uploading files to Sharepoint
+
 ## v24.30.0
 
 - Add cacheableVariables to sharepoint source schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v24.30.0"
+version = "v24.44.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.30.0"
+current_version = "v24.44.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
* [`src/opentaskpy/addons/o365/remotehandlers/sharepoint.py`](diffhunk://#diff-4c4488b1ceaea12191e661947a1f1f238060b2d6a43d9e12a9b62911677b1f0aR317-R342): Added retry logic with exponential backoff for handling 409 errors when uploading files to Sharepoint. This includes setting a maximum number of retries and logging each retry attempt.