### PR TITLE
Fix upload session logic and bump version to v25.34.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - --quiet-level=2
         exclude_types: [csv, json]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.8.6
     hooks:
       - id: bandit
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v25.34.0
+
+- _Fix_ upload session logic to not exit after the first file
+
 ## v25.27.0
 
 - Change file uploads > 200MB to use upload sessions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v25.27.0"
+version = "v25.34.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.27.0"
+current_version = "v25.34.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -7,10 +7,9 @@ from datetime import datetime
 from os import path
 from time import sleep
 
+import opentaskpy.otflogging
 import requests
 from dateutil.tz import tzlocal
-
-import opentaskpy.otflogging
 from opentaskpy.config.variablecaching import cache_utils
 from opentaskpy.exceptions import RemoteTransferError
 from opentaskpy.remotehandlers.remotehandler import RemoteTransferHandler
@@ -386,9 +385,9 @@ class SharepointTransfer(RemoteTransferHandler):
             # Determine size of the file
             file_size = path.getsize(file)
             if file_size > 200000000:
-                if not self._do_upload_session(file, file_name):
+                if self._do_upload_session(file, file_name) != 0:
                     result = 1
-                # Don't do the rest of the logic, as this is done in the function call.
+                # Skip the standard upload logic below, since large file uploads are fully handled by _do_upload_session().
                 continue
 
             # Otherwise do a normal upload

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -7,9 +7,10 @@ from datetime import datetime
 from os import path
 from time import sleep
 
-import opentaskpy.otflogging
 import requests
 from dateutil.tz import tzlocal
+
+import opentaskpy.otflogging
 from opentaskpy.config.variablecaching import cache_utils
 from opentaskpy.exceptions import RemoteTransferError
 from opentaskpy.remotehandlers.remotehandler import RemoteTransferHandler
@@ -385,7 +386,10 @@ class SharepointTransfer(RemoteTransferHandler):
             # Determine size of the file
             file_size = path.getsize(file)
             if file_size > 200000000:
-                return self._do_upload_session(file, file_name)
+                if not self._do_upload_session(file, file_name):
+                    result = 1
+                # Don't do the rest of the logic, as this is done in the function call.
+                continue
 
             # Otherwise do a normal upload
             upload_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root:/{file_name}:/content"


### PR DESCRIPTION
Update the upload session logic to ensure the process continues after the first file upload. Increment the version number and update the changelog accordingly.