### PR TITLE
Add customisable timeout for long running uploads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 26.1.0
     hooks:
       - id: black
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v26.6.0
+
+- Add configurable timeout for large file uploads
+
 ## v25.34.0
 
 - _Fix_ upload session logic to not exit after the first file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v25.34.0"
+version = "v26.6.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.34.0"
+current_version = "v26.6.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
   "pytest-shell",
   "types-requests",
   "types-python-dateutil",
-  "black >= 24.1.1",
+  "black >= 26.1.0",
   "isort",
   "pytest",
   "bumpver",

--- a/src/opentaskpy/addons/o365/remotehandlers/schemas/transfer/sharepoint_destination/protocol.json
+++ b/src/opentaskpy/addons/o365/remotehandlers/schemas/transfer/sharepoint_destination/protocol.json
@@ -17,8 +17,18 @@
     },
     "tenantId": {
       "type": "string"
+    },
+    "largeFileUploadTimeout": {
+      "type": "integer",
+      "default": 300,
+      "minimum": 1
     }
   },
-  "required": ["name", "refreshToken", "clientId", "tenantId"],
+  "required": [
+    "name",
+    "refreshToken",
+    "clientId",
+    "tenantId"
+  ],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/o365/remotehandlers/schemas/transfer/sharepoint_destination/protocol.json
+++ b/src/opentaskpy/addons/o365/remotehandlers/schemas/transfer/sharepoint_destination/protocol.json
@@ -24,11 +24,6 @@
       "minimum": 1
     }
   },
-  "required": [
-    "name",
-    "refreshToken",
-    "clientId",
-    "tenantId"
-  ],
+  "required": ["name", "refreshToken", "clientId", "tenantId"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -519,7 +519,9 @@ class SharepointTransfer(RemoteTransferHandler):
                     upload_session_url,
                     data=chunk,
                     headers=headers,
-                    timeout=60,
+                    timeout=self.spec["protocol"].get(
+                        "largeFileUploadTimeout", 300
+                    ),  # Use configurable timeout for large file uploads
                 )
                 if response.status_code not in (202, 201, 200):
                     self.logger.error(f"Failed to upload chunk: {file_name}")

--- a/tests/test_taskhandler_transfer_sharepoint.py
+++ b/tests/test_taskhandler_transfer_sharepoint.py
@@ -28,7 +28,7 @@ local_destination_definition = {
 sharepoint_destination_definition = {
     "siteHostname": None,
     "siteName": None,
-    "directory": "dest",
+    "directory": "Dev/dest",
     "protocol": {
         "name": "opentaskpy.addons.o365.remotehandlers.sharepoint.SharepointTransfer",
         "refreshToken": "",
@@ -42,6 +42,7 @@ sharepoint_destination_definition = {
             "cacheArgs": {
                 "file": None,
             },
+            "min_cache_age": "600",
         }
     ],
 }
@@ -49,7 +50,7 @@ sharepoint_destination_definition = {
 sharepoint_source_definition = {
     "siteHostname": None,
     "siteName": None,
-    "directory": "src",
+    "directory": "Dev/src",
     "fileRegex": "^test.txt$",
     "protocol": {
         "name": "opentaskpy.addons.o365.remotehandlers.sharepoint.SharepointTransfer",
@@ -71,7 +72,7 @@ sharepoint_source_definition = {
 sharepoint_filewatch_task_definition_source = {
     "siteHostname": None,
     "siteName": None,
-    "directory": "src",
+    "directory": "Dev/src",
     "fileRegex": ".*\\.txt",
     "protocol": {
         "name": "opentaskpy.addons.o365.remotehandlers.sharepoint.SharepointTransfer",
@@ -97,7 +98,7 @@ sharepoint_filewatch_task_definition_source = {
 sharepoint_source_definition_dest = {
     "siteHostname": None,
     "siteName": None,
-    "directory": "dest",
+    "directory": "Dev/dest",
     "fileRegex": "^pca_move_recursive.txt$",
     "protocol": {
         "name": "opentaskpy.addons.o365.remotehandlers.sharepoint.SharepointTransfer",


### PR DESCRIPTION
This pull request introduces a configurable timeout for large file uploads to SharePoint, updates dependencies, and bumps the project version. The main focus is on improving the flexibility and reliability of large file uploads by allowing the timeout to be set via configuration.

**Large File Upload Improvements:**

* Added a new `largeFileUploadTimeout` field (integer, default 300 seconds, minimum 1) to the SharePoint protocol schema to allow configuration of the upload timeout.
* Updated the upload session logic in `sharepoint.py` to use the new configurable timeout for large file uploads instead of a hardcoded value.