### PR TITLE
Add support and tests for document libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ test/testFiles
 test/volume
 creds
 refresh_token*.txt
+.envrc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: env VIRTUAL_ENV=./.venv PATH=./.venv/bin:$PATH mypy
+        entry: mypy
         language: python
         types: [python]
         args: ["--config-file", "mypy.ini"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: env VIRTUAL_ENV=./.venv PATH=./.venv/bin:$PATH mypy
         language: python
         types: [python]
         args: ["--config-file", "mypy.ini"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v26.10.0
+## v26.10.1
 
 - Add support for document libraries in Sharepoint
+- Fixed post copy action renaming to overwrite existing files if they already exist
 
 ## v26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v26.10.0
+
+- Add support for document libraries in Sharepoint
+
 ## v26.8.0
 
 - Add conditionals property to sharepoint_source schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v26.10.1
+## v26.10.2
 
 - Add support for document libraries in Sharepoint
 - Fixed post copy action renaming to overwrite existing files if they already exist

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ As part of the upload, the `bucket-owner-full-control` ACL flag is applied to al
 
 JSON configs for transfers can be defined as follows:
 
+### Handling of document libraries
+
+If you have a document library in your Sharepoint site, you can specify the name of the document library as part of the path. By default, if the destination path does not start with a `/`, then the file will be uploaded to the root of the site (The default Document Library), otherwise it will be uploaded to the document library specified in the first component of the path.
+
 ## Example File Watch Only
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v26.8.0"
+version = "v26.10.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.8.0"
+current_version = "v26.10.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v26.10.1"
+version = "v26.10.2"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.10.1"
+current_version = "v26.10.2"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-o365"
-version = "v26.10.0"
+version = "v26.10.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -46,7 +46,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.10.0"
+current_version = "v26.10.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -154,11 +154,13 @@ class SharepointTransfer(RemoteTransferHandler):
             for file_name, attributes in files.items():
                 # Build up file path below site root
                 file_path = f"{attributes['directory']}/{file_name}"
-                # Get the file id and delete
-                file_id = self.get_file_id_from_path(file_path)
-                delete_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/items/{file_id}"
+                # Get the file url and delete
+                file_url = self.get_file_url_from_path(file_path)
+                if not file_url:
+                    self.logger.error(f"Failed to get file URL for {file_path}")
+                    return 1
                 response = requests.delete(
-                    delete_url,
+                    file_url,
                     headers={
                         "Authorization": "Bearer " + self.credentials["access_token"],
                     },
@@ -177,7 +179,11 @@ class SharepointTransfer(RemoteTransferHandler):
             for file_name, attributes in files.items():
                 # Build up file path below site root
                 file_path = f"{attributes['directory']}/{file_name}"
-                file_id = self.get_file_id_from_path(file_path)
+                file_url = self.get_file_url_from_path(file_path)
+                if not file_url:
+                    self.logger.error(f"Failed to get file URL for {file_path}")
+                    return 1
+
                 new_file = f"{file_name.split('/')[-1]}"
 
                 # getting the archiving path
@@ -199,19 +205,57 @@ class SharepointTransfer(RemoteTransferHandler):
                         self.spec["postCopyAction"]["sub"],
                         file_name,
                     )
-                update_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/items/{file_id}"
+                patch_body = {
+                    "parentReference": {"id": f"{destination_id}"},
+                    "name": f"{new_file}",
+                }
+                patch_headers = {
+                    "Authorization": "Bearer " + self.credentials["access_token"],
+                    "Content-Type": "application/json",
+                }
                 response = requests.patch(
-                    update_url,
-                    headers={
-                        "Authorization": "Bearer " + self.credentials["access_token"],
-                        "Content-Type": "application/json",
-                    },
+                    file_url,
+                    headers=patch_headers,
                     timeout=60,
-                    json={
-                        "parentReference": {"id": f"{destination_id}"},
-                        "name": f"{new_file}",
-                    },
+                    json=patch_body,
                 )
+                if response.status_code == 409:
+                    # Target already exists - delete it and retry (unix-style overwrite)
+                    self.logger.info(
+                        f"Destination file {new_file} already exists, overwriting"
+                    )
+                    conflict_url = self.get_file_url_from_path(
+                        f"{destination_path}/{new_file}"
+                    )
+                    if not conflict_url:
+                        self.logger.error(
+                            f"Failed to get file URL for {destination_path}/{new_file}"
+                        )
+                        return 1
+                    response = requests.delete(
+                        conflict_url,
+                        headers={
+                            "Authorization": (
+                                "Bearer " + self.credentials["access_token"]
+                            ),
+                        },
+                        timeout=60,
+                    )
+                    # Check the response was a success
+                    if response.status_code != 204:
+                        self.logger.error(
+                            f"Failed to delete conflicting file: {new_file}"
+                        )
+                        self.logger.error(f"Got return code: {response.status_code}")
+                        self.logger.error(response.json())
+                        return 1
+
+                    response = requests.patch(
+                        file_url,
+                        headers=patch_headers,
+                        timeout=60,
+                        json=patch_body,
+                    )
                 if response.status_code != 200:
                     self.logger.error(f"Failed to move file: {file_name}")
                     self.logger.error(f"Got return code: {response.status_code}")
@@ -233,13 +277,35 @@ class SharepointTransfer(RemoteTransferHandler):
         for folder in folders:
             # build the path depending on if parent exists
             current_path = f"{current_parent}/{folder}" if current_parent else folder
-            # get folder id from current path
-            folder_id = self.get_file_id_from_path(current_path)
+            # get folder url from current path
+            folder_url = self.get_file_url_from_path(current_path)
 
-            # if folder doesn't exist, create it; else, update parent details
-            if folder_id is None:
+            # if folder doesn't exist, create it and get the actual item ID back
+            if folder_url is None:
                 self.logger.info(f"Folder {folder} does not exist, creating")
                 folder_id = self.create_folder(parent_id, folder)
+            else:
+                # get_fileurld_from_path returns a path-based URL, not a drive item ID;
+                # resolve it to the actual item ID so it can be used in parentReference.id
+                response = requests.get(
+                    folder_url,
+                    headers={
+                        "Authorization": "Bearer " + self.credentials["access_token"],
+                    },
+                    timeout=60,
+                )
+                if response.status_code == 404:
+                    self.logger.info(f"Folder {folder} does not exist, creating")
+                    folder_id = self.create_folder(parent_id, folder)
+                elif response.status_code == 200:
+                    folder_id = response.json()["id"]
+                else:
+                    self.logger.error(f"Failed to resolve folder: {current_path}")
+                    self.logger.error(response.json())
+                    raise RemoteTransferError(
+                        f"Failed to resolve folder: {current_path}"
+                    )
+
             # updating parent info for the next folder in sequence
             current_parent = current_path
             parent_id = folder_id
@@ -365,7 +431,7 @@ class SharepointTransfer(RemoteTransferHandler):
         for file in files:
             # Strip the directory from the file
             file_name = file.split("/")[-1]
-            file_url = self.get_file_id_from_path(
+            file_url = self.get_file_url_from_path(
                 self.spec["directory"] + "/" + file_name
             )
 
@@ -455,18 +521,20 @@ class SharepointTransfer(RemoteTransferHandler):
         # 3. Trigger the appropriate URI endpoint to upload the file
 
         # Determine if the file already exists
-        file_id = self.get_file_id_from_path(file_name)
-        if file_id is None:
+        file_url = self.get_file_url_from_path(file_name)
+        if file_url is None:
             self.logger.info(f"File {file_name} does not already exist.")
-            # Get the parent item id, using the dirname of the file
-            parent_folder_id = self.get_file_id_from_path(path.dirname(file_name))
+            # Get the parent item url, using the dirname of the file
+            parent_folder_url = self.get_file_url_from_path(path.dirname(file_name))
             file_name_basename = path.basename(file_name)
 
-            upload_session_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/items/{parent_folder_id}:/{file_name_basename}:/createUploadSession"
+            upload_session_url = (
+                f"{parent_folder_url}:/{file_name_basename}:/createUploadSession"
+            )
 
         else:
             self.logger.info(f"File {file_name} already exists. Replacing file.")
-            upload_session_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/items/{file_id}/createUploadSession"
+            upload_session_url = f"{file_url}:/createUploadSession"
 
         response = requests.post(
             upload_session_url,
@@ -536,10 +604,11 @@ class SharepointTransfer(RemoteTransferHandler):
 
                 # If it's a 201, then we are done with the upload
                 if response.status_code == 201 or (
-                    response.status_code == 200 and file_id is not None
+                    response.status_code == 200 and file_url is not None
                 ):
-                    file_id = response.json()["id"]
-                    self.logger.info(f"Successfully uploaded file. File ID: {file_id}")
+                    self.logger.info(
+                        f"Successfully uploaded file. File ID: {response.json()['id']}"
+                    )
                 else:
                     self.logger.info(f"Uploaded chunk {i + 1} of {num_chunks}")
 
@@ -569,11 +638,11 @@ class SharepointTransfer(RemoteTransferHandler):
             file_path = f"{attributes['directory']}/{file_name}"
 
             try:
-                # Get the item id based on source path
-                file_id = self.get_file_id_from_path(file_path)
-                # Download file using item id
+                # Get the item url based on source path
+                file_url = self.get_file_url_from_path(file_path)
+                # Download file using item url
                 self.logger.info(f"Downloading file: {file_name}")
-                download_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/items/{file_id}/content"
+                download_url = f"{file_url}:/content"
                 response = requests.get(
                     download_url,
                     headers={
@@ -616,7 +685,7 @@ class SharepointTransfer(RemoteTransferHandler):
     def tidy(self) -> None:
         """Nothing to tidy."""
 
-    def get_file_id_from_path(self, file_path: str) -> str | None:
+    def get_file_url_from_path(self, file_path: str) -> str | None:
         """Returns the id for a sharepoint drive item from the path."""
         if file_path == "":  # We are dealing with the root folder
             item_url = (
@@ -663,7 +732,9 @@ class SharepointTransfer(RemoteTransferHandler):
                 self.logger.error(
                     f"Failed to find document library with name {library_name}"
                 )
-                return None
+                raise RemoteTransferError(
+                    f"Failed to find Document Library named {library_name}"
+                )
 
             return f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root:/{re.sub(r'/+', '/', file_path)}"
 

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -365,6 +365,10 @@ class SharepointTransfer(RemoteTransferHandler):
         for file in files:
             # Strip the directory from the file
             file_name = file.split("/")[-1]
+            file_url = self.get_file_id_from_path(
+                self.spec["directory"] + "/" + file_name
+            )
+
             # Handle any rename that might be specified in the spec
             if "rename" in self.spec:
                 rename_regex = self.spec["rename"]["pattern"]
@@ -391,7 +395,8 @@ class SharepointTransfer(RemoteTransferHandler):
                 continue
 
             # Otherwise do a normal upload
-            upload_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root:/{file_name}:/content"
+            upload_url = f"{file_url}:/content"
+            self.logger.info(f"Using upload url: {upload_url}")
             with open(file, "rb") as f:
                 max_retries = 5
                 retry_delay = 1
@@ -618,7 +623,49 @@ class SharepointTransfer(RemoteTransferHandler):
                 f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root"
             )
         else:
-            item_url = f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root:/{file_path}"
+            parts = file_path.split("/")
+            file_name = parts[-1]
+            # Remove the filename from the path
+            o365_file_path = "/".join(parts[:-1])
+
+            if o365_file_path.startswith("/"):
+                path_parts = o365_file_path.split("/")
+                # Get the first part of the path, which is the document library name
+                library_name = path_parts[1]
+                # file path then needs to be the rest of the path
+                o365_file_path = "/".join(path_parts[2:])
+
+                # If the path starts with a / then it's a document library, we need to get the id of the document library
+                # Do a GET request to /sites/{siteId}/drives to get the document libraries
+                response = requests.get(
+                    f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drives",
+                    headers={
+                        "Authorization": "Bearer " + self.credentials["access_token"],
+                    },
+                    timeout=60,
+                )
+                if response.status_code != 200:
+                    self.logger.error("Failed to get document libraries")
+                    self.logger.error(response.json())
+                    raise RemoteTransferError("Failed to get document libraries")
+
+                document_libraries = response.json()["value"]
+
+                for document_library in document_libraries:
+                    if document_library["name"] == library_name:
+                        item_path = (
+                            f"{o365_file_path}/{file_name}"
+                            if o365_file_path
+                            else file_name
+                        )
+                        return f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drives/{document_library['id']}/root:/{item_path}"
+
+                self.logger.error(
+                    f"Failed to find document library with name {library_name}"
+                )
+                return None
+
+            return f"https://graph.microsoft.com/v1.0/sites/{self.site_id}/drive/root:/{re.sub(r'/+', '/', file_path)}"
 
         response = requests.get(
             item_url,

--- a/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
+++ b/src/opentaskpy/addons/o365/remotehandlers/sharepoint.py
@@ -285,7 +285,7 @@ class SharepointTransfer(RemoteTransferHandler):
                 self.logger.info(f"Folder {folder} does not exist, creating")
                 folder_id = self.create_folder(parent_id, folder)
             else:
-                # get_fileurld_from_path returns a path-based URL, not a drive item ID;
+                # get_file_url_from_path returns a path-based URL, not a drive item ID;
                 # resolve it to the actual item ID so it can be used in parentReference.id
                 response = requests.get(
                     folder_url,

--- a/tests/test_taskhandler_transfer_sharepoint.py
+++ b/tests/test_taskhandler_transfer_sharepoint.py
@@ -153,6 +153,7 @@ def o365_creds():
         "sharepointHost": os.getenv("SHAREPOINT_HOST"),
         "refreshToken": os.getenv("REFRESH_TOKEN"),
         "rootDir": f"{current_dir}/../",
+        "document_library": os.getenv("DOCUMENT_LIBRARY"),
     }
 
 
@@ -278,6 +279,33 @@ def test_local_to_sharepoint_transfer(tmpdir, o365_creds):
     assert transfer_obj.run()
 
 
+def test_local_to_sharepoint_transfer_document_library(tmpdir, o365_creds):
+
+    task_definition = {
+        "type": "transfer",
+        "source": deepcopy(local_source_definition),
+        "destination": [deepcopy(sharepoint_destination_definition)],
+    }
+
+    task_definition = setup_creds_for_transfer(task_definition, o365_creds)
+
+    # Set the directory to the temp directory
+    task_definition["source"]["directory"] = tmpdir
+    task_definition["source"]["fileRegex"] = "^test.txt$"
+
+    task_definition["destination"][0][
+        "directory"
+    ] = f"/{o365_creds['document_library']}/Dev/dest"
+
+    # Create a file in the tmpdir
+    with open(f"{tmpdir}/test.txt", "w") as f:
+        f.write("test")
+
+    transfer_obj = transfer.Transfer(None, "local-to-sharepoint-copy", task_definition)
+
+    assert transfer_obj.run()
+
+
 def test_local_to_sharepoint_transfer_large_file(tmpdir, o365_creds):
 
     # Generate a random filename
@@ -299,6 +327,44 @@ def test_local_to_sharepoint_transfer_large_file(tmpdir, o365_creds):
     # Set the directory to the temp directory
     task_definition["source"]["directory"] = tmpdir
     task_definition["source"]["fileRegex"] = f"^{random}.bin$"
+
+    task_definition["destination"][0]["directory"] = f"Dev/dest/{random}/{random}"
+
+    transfer_obj = transfer.Transfer(
+        None, "local-to-sharepoint-copy-large-file", task_definition
+    )
+
+    assert transfer_obj.run()
+
+    # Now attempt to upload the same file again, this should use different logic, but still work
+    assert transfer_obj.run()
+
+
+def test_local_to_sharepoint_transfer_large_file_document_library(tmpdir, o365_creds):
+
+    # Generate a random filename
+    random = randint(1000, 9999)
+
+    # Create a large file
+    large_file_path = f"{tmpdir}/{random}.bin"
+    with open(large_file_path, "wb") as f:
+        f.write(os.urandom(110 * 1024 * 1024))  # 110 MB of random data
+
+    task_definition = {
+        "type": "transfer",
+        "source": deepcopy(local_source_definition),
+        "destination": [deepcopy(sharepoint_destination_definition)],
+    }
+
+    task_definition = setup_creds_for_transfer(task_definition, o365_creds)
+
+    # Set the directory to the temp directory
+    task_definition["source"]["directory"] = tmpdir
+    task_definition["source"]["fileRegex"] = f"^{random}.bin$"
+
+    task_definition["destination"][0][
+        "directory"
+    ] = f"/{o365_creds['document_library']}/Dev/dest/{random}/{random}"
 
     transfer_obj = transfer.Transfer(
         None, "local-to-sharepoint-copy-large-file", task_definition

--- a/tests/test_taskhandler_transfer_sharepoint.py
+++ b/tests/test_taskhandler_transfer_sharepoint.py
@@ -154,6 +154,7 @@ def o365_creds():
         "refreshToken": os.getenv("REFRESH_TOKEN"),
         "rootDir": f"{current_dir}/../",
         "document_library": os.getenv("DOCUMENT_LIBRARY"),
+        "source_folder": os.getenv("SOURCE_FOLDER"),
     }
 
 
@@ -245,7 +246,9 @@ def test_sharepoint_filewatch_sub_dir(tmpdir, o365_creds):
     )
 
     # Set the directory to the src sub directory
-    sharepoint_filewatch_task_definition["source"]["directory"] = "src"
+    sharepoint_filewatch_task_definition["source"]["directory"] = o365_creds[
+        "source_folder"
+    ]
     # Set the destination directory to the temp directory
     sharepoint_filewatch_task_definition["destination"][0]["directory"] = tmpdir.strpath
 
@@ -389,7 +392,7 @@ def test_sharepoint_pca_move_recursive(tmpdir, o365_creds):
     # Set the directory to the temp directory
     task_definition["source"]["directory"] = tmpdir
     task_definition["source"]["fileRegex"] = "^pca_move_recursive4.txt$"
-    task_definition["destination"][0]["directory"] = "dest"
+    task_definition["destination"][0]["directory"] = o365_creds["source_folder"]
 
     # Create a file in the tmpdir
     with open(f"{tmpdir}/pca_move_recursive4.txt", "w") as f:
@@ -411,11 +414,13 @@ def test_sharepoint_pca_move_recursive(tmpdir, o365_creds):
     task_definition["destination"][0]["directory"] = tmpdir.strpath
 
     # Set the PCA with move
-    task_definition["source"]["directory"] = "dest"
+    task_definition["source"]["directory"] = o365_creds["source_folder"]
     task_definition["source"]["fileRegex"] = "^pca_move_recursive4.txt$"
     task_definition["source"]["postCopyAction"] = {
         "action": "move",
-        "destination": "testing_7/testing_8",
+        "destination": (
+            o365_creds["source_folder"] + "/pca_move_recursive4/testing_7/testing_8"
+        ),
     }
     transfer_obj = transfer.Transfer(None, "sharepoint-to-local-copy", task_definition)
 
@@ -480,7 +485,9 @@ def test_sharepoint_pca_delete(tmpdir, o365_creds):
     # Set the directory to the temp directory
     task_definition["source"]["directory"] = tmpdir
     task_definition["source"]["fileRegex"] = "^pca_delete.txt$"
-    task_definition["destination"][0]["directory"] = "src/pca_delete"
+    task_definition["destination"][0]["directory"] = (
+        o365_creds["source_folder"] + "/pca_delete"
+    )
 
     # Create a file in the tmpdir
     with open(f"{tmpdir}/pca_delete.txt", "w") as f:
@@ -502,7 +509,7 @@ def test_sharepoint_pca_delete(tmpdir, o365_creds):
     task_definition["destination"][0]["directory"] = tmpdir.strpath
 
     # Set the PCA with delete
-    task_definition["source"]["directory"] = "src/pca_delete"
+    task_definition["source"]["directory"] = o365_creds["source_folder"] + "/pca_delete"
     task_definition["source"]["fileRegex"] = "^pca_delete.txt$"
     task_definition["source"]["postCopyAction"] = {
         "action": "delete",
@@ -525,7 +532,9 @@ def test_sharepoint_pca_move(tmpdir, o365_creds):
     # Set the directory to the temp directory
     task_definition["source"]["directory"] = tmpdir
     task_definition["source"]["fileRegex"] = "^pca_move.txt$"
-    task_definition["destination"][0]["directory"] = "src/pca_move"
+    task_definition["destination"][0]["directory"] = (
+        o365_creds["source_folder"] + "/pca_move"
+    )
 
     # Create a file in the tmpdir
     with open(f"{tmpdir}/pca_move.txt", "w") as f:
@@ -547,11 +556,11 @@ def test_sharepoint_pca_move(tmpdir, o365_creds):
     task_definition["destination"][0]["directory"] = tmpdir.strpath
 
     # Set the PCA with move
-    task_definition["source"]["directory"] = "src/pca_move"
+    task_definition["source"]["directory"] = o365_creds["source_folder"] + "/pca_move"
     task_definition["source"]["fileRegex"] = "^pca_move.txt$"
     task_definition["source"]["postCopyAction"] = {
         "action": "move",
-        "destination": "archive2",
+        "destination": o365_creds["source_folder"] + "/pca_move/archive2",
     }
     transfer_obj = transfer.Transfer(None, "sharepoint-to-local-copy", task_definition)
 
@@ -571,7 +580,9 @@ def test_sharepoint_pca_rename(tmpdir, o365_creds):
     # Set the directory to the temp directory
     task_definition["source"]["directory"] = tmpdir
     task_definition["source"]["fileRegex"] = "^pca_rename.txt$"
-    task_definition["destination"][0]["directory"] = "src/pca_rename"
+    task_definition["destination"][0]["directory"] = (
+        o365_creds["source_folder"] + "/pca_rename"
+    )
 
     # Create a file in the tmpdir
     with open(f"{tmpdir}/pca_rename.txt", "w") as f:
@@ -593,11 +604,11 @@ def test_sharepoint_pca_rename(tmpdir, o365_creds):
     task_definition["destination"][0]["directory"] = tmpdir.strpath
 
     # Set the PCA with rename
-    task_definition["source"]["directory"] = "src/pca_rename"
+    task_definition["source"]["directory"] = o365_creds["source_folder"] + "/pca_rename"
     task_definition["source"]["fileRegex"] = "^pca_rename.txt$"
     task_definition["source"]["postCopyAction"] = {
         "action": "rename",
-        "destination": "archive",
+        "destination": o365_creds["source_folder"] + "/pca_rename/archive",
         "pattern": "rename",
         "sub": "renamed",
     }


### PR DESCRIPTION
This pull request adds support for handling document libraries in SharePoint transfers. It updates both the implementation and documentation to allow users to specify a document library as part of the path, and introduces new tests to ensure this functionality works for both regular and large file uploads.

**SharePoint Document Library Support:**

* Updated the SharePoint handler (`sharepoint.py`) to allow specifying a document library in the destination path. The new logic parses the path, retrieves the correct document library ID from Microsoft Graph, and constructs the appropriate upload URL. [[1]](diffhunk://#diff-4c4488b1ceaea12191e661947a1f1f238060b2d6a43d9e12a9b62911677b1f0aL621-R668) [[2]](diffhunk://#diff-4c4488b1ceaea12191e661947a1f1f238060b2d6a43d9e12a9b62911677b1f0aR368-R371) [[3]](diffhunk://#diff-4c4488b1ceaea12191e661947a1f1f238060b2d6a43d9e12a9b62911677b1f0aL394-R399)
* Updated the `README.md` to document how to specify a document library in the path for SharePoint uploads.
* Added a changelog entry for v26.10.0 noting support for document libraries.

**Testing Enhancements:**

* Added new tests to `test_taskhandler_transfer_sharepoint.py` for uploading to document libraries, including both standard and large files, and updated test credentials to include a `document_library` parameter. [[1]](diffhunk://#diff-5a3f12c228f1135dad1b4aa38f675e8e76468d173d0abbb8160adcc4bacc1327R282-R308) [[2]](diffhunk://#diff-5a3f12c228f1135dad1b4aa38f675e8e76468d173d0abbb8160adcc4bacc1327R331-R368) [[3]](diffhunk://#diff-5a3f12c228f1135dad1b4aa38f675e8e76468d173d0abbb8160adcc4bacc1327R156)

**Tooling:**

* Modified the `mypy` pre-commit hook to ensure it runs within the project's virtual environment, improving consistency of type checking.